### PR TITLE
Added check that self.times is not empty in Utils.

### DIFF
--- a/TCMask/Utils.swift
+++ b/TCMask/Utils.swift
@@ -25,7 +25,9 @@ class StopWatch {
     }
     
     func abort() {
-        self.times.removeLast()
+        if !self.times.isEmpty {
+            self.times.removeLast()
+        }
     }
 }
 


### PR DESCRIPTION
This prevents the crash raised in issue #48 